### PR TITLE
Mutex sleep

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -92,6 +92,12 @@ Install the gem with:
 
 See spec/process_shared/condition_variable_spec.rb for examples/usage.
 
+== Notes
+
+Note that REE with its COW friendly GC might save you some memory when you fork processes
+(or you could turn off the GC for short lived child processes).  2.0 is supposed to also
+have a COW friendly GC.
+
 == Todo
 
 * Test ConditionVariable

--- a/README.rdoc
+++ b/README.rdoc
@@ -88,6 +88,10 @@ Install the gem with:
 
     mem.read_object.must_equal ['a', 'b']
 
+== ConditionVariables
+
+See spec/process_shared/condition_variable_spec.rb for examples/usage.
+
 == Todo
 
 * Test ConditionVariable

--- a/spec/process_shared/mutex_sleep_spec.rb
+++ b/spec/process_shared/mutex_sleep_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+require 'process_shared/condition_variable'
+
+module ProcessShared
+
+  describe ConditionVariable do
+    it 'has a Mutex#sleep/wakeup method' do
+      mutex = Mutex.new
+      mem = SharedMemory.new(:int)
+      mem.write_int(0)
+
+      a = fork {
+        mutex.synchronize {
+          mutex.sleep
+        }
+        mem.write_int(1)
+        Kernel.exit!
+      }
+      sleep 0.2 
+      b = fork {
+        mutex.wakeup_first
+        Kernel.exit!
+      }
+
+      ::Process.wait(a)
+      ::Process.wait(b)
+      mem.read_int.must_equal(1)
+    end
+
+  end
+
+end


### PR DESCRIPTION
ok I have branch "mergeable" with some docu tweaks, which I (oops) pulled into branch mutex_sleep, which attempts to add a

Mutex#sleep method, with a fake Thread#wakeup equivalent.  Basically so that I can then (next) use that method to implement SizedQueue from the the code from the 1.9 stdlib with fewer changes. Let me know your take on this approach (I could just use CV's in the SizedQueue code, but thought while I was at it bringing it closer to par with Thread# methods might be reasonable).
Thanks.
-roger-
