### PR TITLE
Fix ConditionVariable#signal to only post if semaphore has waiters

### DIFF
--- a/lib/process_shared/condition_variable.rb
+++ b/lib/process_shared/condition_variable.rb
@@ -16,7 +16,9 @@ module ProcessShared
     end
 
     def signal
-      @sem.post
+      @internal.synchronize do
+        @sem.post unless @waiting.read_int.zero?
+      end
     end
 
     def wait(mutex, timeout = nil)

--- a/spec/process_shared/condition_variable_spec.rb
+++ b/spec/process_shared/condition_variable_spec.rb
@@ -63,5 +63,19 @@ module ProcessShared
         (Time.now.to_f - start).must be_gte(0.1)
       }
     end
+
+    it 'correctly handles #signal when no waiters' do
+      mutex = Mutex.new
+      cond = ConditionVariable.new
+
+      # fix for bug: #wait not waiting after unmatched call to #signal
+      cond.signal
+
+      mutex.synchronize {
+        start = Time.now.to_f
+        cond.wait(mutex, 0.1)
+        (Time.now.to_f - start).must be_gte(0.1)
+      }
+    end
   end
 end


### PR DESCRIPTION
This fixes a bug where calls to #signal would end up "over-posting"
the semaphore, causing subsequent waits to return immediately until
the semaphore value is back down to zero.
